### PR TITLE
fixed: #26 Lambda Invoke is converted without explicit delegate type

### DIFF
--- a/ExpressionToCodeLib/ExpressionToCodeImpl.cs
+++ b/ExpressionToCodeLib/ExpressionToCodeImpl.cs
@@ -266,6 +266,8 @@ namespace ExpressionToCodeLib {
 
         public void DispatchInvoke(Expression e) {
             var ie = (InvocationExpression)e;
+            if (ie.Expression.NodeType == ExpressionType.Lambda)
+                Sink("new " + CSharpFriendlyTypeName.Get(ie.Expression.Type));
             NestExpression(ie.NodeType, ie.Expression);
             ArgListDispatch(ie.Arguments, ie);
         }

--- a/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
+++ b/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
@@ -444,9 +444,26 @@ namespace ExpressionToCodeTest {
                 @"() => new ClassA(ref x, out y))",
                 ExpressionToCode.ToCode(() => myDelegate(ref x, out y)));
         }
+
+        [Test]
+        public void FuncInvocation() {
+            Assert.AreEqual(
+                "() => new Func<int>(() => 1)()",
+                ExpressionToCode.ToCode(() => new Func<int>(() => 1)()));
+        }
+
+        [Test]
+        public void CustomDelegateInvocation()
+        {
+            Assert.AreEqual(
+                "() => new CustomDelegate(n => n + 1)(1)",
+                ExpressionToCode.ToCode(() => new CustomDelegate(n => n + 1)(1)));
+        }
     }
 
     public delegate int DelegateWithRefAndOut(ref int someVar, out int anotherVar);
+
+    public delegate int CustomDelegate(int input);
 
     static class StaticHelperClass {
         public static long AnExtensionMethod(this DateTime date, ref int tickOffset, int dayOffset, out long alternateOut) {


### PR DESCRIPTION
Tested on `Func` and custom delegate.