### PR TITLE
- made safe rename according .NET guidelines

### DIFF
--- a/ExpressionToCodeLib/ExpressionToCode.cs
+++ b/ExpressionToCodeLib/ExpressionToCode.cs
@@ -11,10 +11,18 @@ namespace ExpressionToCodeLib {
         public static string ToCode<T, T1, T2>(Expression<Func<T, T1, T2>> e) { return ToCode((Expression)e); }
         public static string ToCode<T, T1>(Expression<Func<T, T1>> e) { return ToCode((Expression)e); }
         public static string ToCode<T>(Expression<Func<T>> e) { return ToCode((Expression)e); }
-        public static string AnnotatedToCode<T, T1, T2, T3>(Expression<Func<T, T1, T2, T3>> e) { return AnnotatedToCode((Expression)e); }
-        public static string AnnotatedToCode<T, T1, T2>(Expression<Func<T, T1, T2>> e) { return AnnotatedToCode((Expression)e); }
-        public static string AnnotatedToCode<T, T1>(Expression<Func<T, T1>> e) { return AnnotatedToCode((Expression)e); }
-        public static string AnnotatedToCode<T>(Expression<Func<T>> e) { return AnnotatedToCode((Expression)e); }
+        public static string ToAnnotatedCode<T, T1, T2, T3>(Expression<Func<T, T1, T2, T3>> e) { return ToAnnotatedCode((Expression)e); }
+        public static string ToAnnotatedCode<T, T1, T2>(Expression<Func<T, T1, T2>> e) { return ToAnnotatedCode((Expression)e); }
+        public static string ToAnnotatedCode<T, T1>(Expression<Func<T, T1>> e) { return ToAnnotatedCode((Expression)e); }
+        public static string ToAnnotatedCode<T>(Expression<Func<T>> e) { return ToAnnotatedCode((Expression)e); }
+        [Obsolete("Use ToAnnotatedCode")]
+        public static string AnnotatedToCode<T, T1, T2, T3>(Expression<Func<T, T1, T2, T3>> e) { return ToAnnotatedCode((Expression)e); }
+        [Obsolete("Use ToAnnotatedCode")]
+        public static string AnnotatedToCode<T, T1, T2>(Expression<Func<T, T1, T2>> e) { return ToAnnotatedCode((Expression)e); }
+        [Obsolete("Use ToAnnotatedCode")]
+        public static string AnnotatedToCode<T, T1>(Expression<Func<T, T1>> e) { return ToAnnotatedCode((Expression)e); }
+        [Obsolete("Use ToAnnotatedCode")]
+        public static string AnnotatedToCode<T>(Expression<Func<T>> e) { return ToAnnotatedCode((Expression)e); }
 
         public static string ToCode(Expression e) {
             StringBuilder sb = new StringBuilder();
@@ -27,9 +35,11 @@ namespace ExpressionToCodeLib {
             return sb.ToString();
         }
 
-        public static string AnnotatedToCode(Expression expr) { return AnnotatedToCode(expr, null, false); }
+        public static string ToAnnotatedCode(Expression expr) { return ToAnnotatedCode(expr, null, false); }
+        [Obsolete("Use ToAnnotatedCode")]
+        public static string AnnotatedToCode(Expression expr) { return ToAnnotatedCode(expr, null, false); }
 
-        internal static string AnnotatedToCode(Expression expr, string msg, bool ignoreOutermostValue) {
+        internal static string ToAnnotatedCode(Expression expr, string msg, bool ignoreOutermostValue) {
             var splitLine = ExpressionToStringWithValues(expr, ignoreOutermostValue);
 
             var exprWithStalkedValues = new StringBuilder();

--- a/ExpressionToCodeLib/PAssert.cs
+++ b/ExpressionToCodeLib/PAssert.cs
@@ -26,7 +26,7 @@ namespace ExpressionToCodeLib {
         }
 
         static Exception Err(Expression<Func<bool>> assertion, string msg, Exception innerException) {
-            return UnitTestingFailure.AssertionExceptionFactory(ExpressionToCode.AnnotatedToCode(assertion.Body, msg, true), innerException);
+            return UnitTestingFailure.AssertionExceptionFactory(ExpressionToCode.ToAnnotatedCode(assertion.Body, msg, true), innerException);
         }
     }
 }


### PR DESCRIPTION
- all method which do transformation with allocation of memory are named in .NET and 3rd party libs are started with `To`

- [Obsolete("Use ToAnnotatedCode")] does not breaks any running code and suggest what to do. Just adds warning into build of dependent code.

- `AnnotatedToCode` is misleading names rough violation of .NET guidelines of naming methods

- `To` goes well with ToCode ToValuedCode ToSyntaxTree etc