### PR TITLE
added: IExpressionToCode interface with ToCode methods and full range of...

### DIFF
--- a/ExpressionToCodeLib/CSharpFriendlyTypeName.cs
+++ b/ExpressionToCodeLib/CSharpFriendlyTypeName.cs
@@ -5,7 +5,9 @@ using System.Text;
 
 namespace ExpressionToCodeLib {
     static class CSharpFriendlyTypeName {
-        public static string Get(Type type) { return GenericTypeName(type) ?? ArrayTypeName(type) ?? AliasName(type) ?? NormalName(type); }
+        public static string Get(Type type, bool fullName = false) {
+            return GenericTypeName(type, fullName) ?? ArrayTypeName(type) ?? AliasName(type) ?? NormalName(type, fullName);
+        }
 
         static string AliasName(Type type) {
             if (type == typeof(bool)) {
@@ -43,9 +45,12 @@ namespace ExpressionToCodeLib {
             }
         }
 
-        static string NormalName(Type type) { return (type.DeclaringType == null || type.IsGenericParameter ? "" : Get(type.DeclaringType) + ".") + type.Name; }
+        static string NormalName(Type type, bool fullName = false) {
+            return (type.DeclaringType == null || type.IsGenericParameter ? "" : Get(type.DeclaringType) + ".")
+                + (fullName ? type.FullName ?? type.Name : type.Name);
+        }
 
-        static string GenericTypeName(Type type) {
+        static string GenericTypeName(Type type, bool fullName = false) {
             if (!type.IsGenericType) {
                 return null;
             }
@@ -60,7 +65,7 @@ namespace ExpressionToCodeLib {
             var revNestedTypeNames = new List<string>();
 
             while (type != null) {
-                var name = type.Name;
+                var name = fullName ? type.FullName ?? type.Name : type.Name;
                 var backtickIdx = name.IndexOf('`');
                 if (backtickIdx < 0) {
                     revNestedTypeNames.Add(name);

--- a/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
+++ b/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
@@ -466,6 +466,14 @@ namespace ExpressionToCodeTest {
                 "() => new CustomDelegate(n => n + 1)(1)",
                 ExpressionToCode.ToCode(() => new CustomDelegate(n => n + 1)(1)));
         }
+
+        [Test]
+        public void FullTypeName_IfCorrespondingRuleSpecified()
+        {
+            Assert.AreEqual(
+                "() => new ExpressionToCodeTest.ClassA()",
+                ExpressionToCode.With(rules => rules.WithFullTypeNames()).ToCode(() => new ClassA()));
+        }
     }
 
     public delegate int DelegateWithRefAndOut(ref int someVar, out int anotherVar);

--- a/ExpressionToCodeTest/GenericsTestClasses.cs
+++ b/ExpressionToCodeTest/GenericsTestClasses.cs
@@ -189,7 +189,19 @@ namespace ExpressionToCodeTest {
                 ExpressionToCode.ToCode(() => GenericClass<int>.IsFunc2OfType((int x) => x))
                 );
         }
+
+        [Test]
+        public void GenericMethodCall_WhenSomeNotInferredTypeArguments_ShouldExplicitlySpecifyTypeArguments()
+        {
+            Assert.AreEqual(
+                "() => MakeMe<Cake, string>(() => new Cake())",
+                ExpressionToCode.With(rules => rules.WithExplicitMethodTypeArgs()).ToCode(() => MakeMe<Cake, string>(() => new Cake())));
+        }
+
+        T MakeMe<T, TNotInferredFromArgument>(Func<T> maker) { return maker(); }
     }
+
+    internal class Cake { }
 
     class GenericClass<T> {
         T val;


### PR DESCRIPTION
added: IExpressionToCode interface with ToCode method and full range of ToCode extension methods.
added: Rules for specifying FullTypeNames and ExplicitMethodTypeArgs.
fixed: #13 Explicit type parameters for methods omitted - Instead of inferring which is complex task, I want to have setting to turn it on for my use case, and be off by default.

Hello, 

I made change towards non-static ExpressionToCode. It is incomplete because I did not touch AnnotatedToCode. I want to hear you feedback first on this approach.

The reason in the first place was to support two use cases: with Type.FullName instead of just name, and the one related to #13 .

Hope it is right direction,
Maksim
