### PR TITLE
IExpressionToCode with rules for FullTypeNames and ExplicitMethodTypeArgs

### DIFF
--- a/ExpressionToCodeLib/CSharpFriendlyTypeName.cs
+++ b/ExpressionToCodeLib/CSharpFriendlyTypeName.cs
@@ -72,10 +72,12 @@ namespace ExpressionToCodeLib {
             while (type != null) {
                 var name = useFullType ? type.FullName ?? type.Name : type.Name;
                 var backtickIdx = name.IndexOf('`');
-                if (backtickIdx < 0) {
+                if (backtickIdx == -1) {
                     revNestedTypeNames.Add(name);
                 } else {
-                    var thisTypeArgCount = int.Parse(name.Substring(backtickIdx + 1));
+                    var afterArgCountIdx = name.IndexOf('[', backtickIdx + 1);
+                    if (afterArgCountIdx == -1) afterArgCountIdx = name.Length;
+                    var thisTypeArgCount = int.Parse(name.Substring(backtickIdx + 1, afterArgCountIdx - backtickIdx - 1));
                     var argsNames = new List<string>();
                     for (int i = typeArgIdx - thisTypeArgCount; i < typeArgIdx; i++) {
                         argsNames.Add(Get(typeArgs[i], useFullType));

--- a/ExpressionToCodeLib/CSharpFriendlyTypeName.cs
+++ b/ExpressionToCodeLib/CSharpFriendlyTypeName.cs
@@ -5,7 +5,9 @@ using System.Text;
 
 namespace ExpressionToCodeLib {
     static class CSharpFriendlyTypeName {
-        public static string Get(Type type) { return GenericTypeName(type) ?? ArrayTypeName(type) ?? AliasName(type) ?? NormalName(type); }
+        public static string Get(Type type, bool fullName = false) {
+            return GenericTypeName(type, fullName) ?? ArrayTypeName(type) ?? AliasName(type) ?? NormalName(type, fullName);
+        }
 
         static string AliasName(Type type) {
             if (type == typeof(bool)) {
@@ -43,9 +45,12 @@ namespace ExpressionToCodeLib {
             }
         }
 
-        static string NormalName(Type type) { return (type.DeclaringType == null || type.IsGenericParameter ? "" : Get(type.DeclaringType) + ".") + type.Name; }
+        static string NormalName(Type type, bool fullName = false) {
+            return (type.DeclaringType == null || type.IsGenericParameter ? "" : Get(type.DeclaringType) + ".")
+                + (fullName ? type.FullName ?? type.Name : type.Name);
+        }
 
-        static string GenericTypeName(Type type) {
+        static string GenericTypeName(Type type, bool fullName = false) {
             if (!type.IsGenericType) {
                 return null;
             }
@@ -60,7 +65,7 @@ namespace ExpressionToCodeLib {
             var revNestedTypeNames = new List<string>();
 
             while (type != null) {
-                var name = type.Name;
+                var name = fullName ? type.FullName ?? type.Name : type.Name;
                 var backtickIdx = name.IndexOf('`');
                 if (backtickIdx < 0) {
                     revNestedTypeNames.Add(name);

--- a/ExpressionToCodeTest/EnumTests.cs
+++ b/ExpressionToCodeTest/EnumTests.cs
@@ -156,6 +156,32 @@ namespace ExpressionToCodeTest {
                 //but it does here!
                 ExpressionToCode.ToCode(() => (SomeFlagsEnum?)a == b));
         }
+        
+        [Test]
+        public void NullableEnumCornerCases_FullNames()
+        {
+            SomeEnum? a = SomeEnum.A;
+            SomeFlagsEnum? b = SomeFlagsEnum.B;
+
+            var expressionToCode = ExpressionToCode.With(r => r.WithFullTypeNames());
+
+            Assert.AreEqual(
+                @"() => a == ExpressionToCodeTest.SomeEnum.B",
+                //C# compiler does not preserve this type information.
+                expressionToCode.ToCode(() => a == (SomeEnum)SomeFlagsEnum.A));
+            Assert.AreEqual(
+                @"() => a == ((ExpressionToCodeTest.SomeEnum)4)",
+                //C# compiler does not preserve this type information; requires cast
+                expressionToCode.ToCode(() => a == (SomeEnum)SomeFlagsEnum.C));
+            Assert.AreEqual(
+                @"() => a == (ExpressionToCodeTest.SomeEnum)b",
+                //but it does here!
+                expressionToCode.ToCode(() => a == (SomeEnum)b));
+            Assert.AreEqual(
+                @"() => (ExpressionToCodeTest.SomeFlagsEnum?)a == b",
+                //but it does here!
+                expressionToCode.ToCode(() => (SomeFlagsEnum?)a == b));
+        }
 
         [Test]
         public void FlagsEnumConstant() {

--- a/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
+++ b/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
@@ -474,6 +474,16 @@ namespace ExpressionToCodeTest {
                 "() => new ExpressionToCodeTest.ClassA()",
                 ExpressionToCode.With(rules => rules.WithFullTypeNames()).ToCode(() => new ClassA()));
         }
+
+        [Test]
+        public void FullTypeName_ForNestedType()
+        {
+            Assert.AreEqual(
+                "() => new ExpressionToCodeTest.ExpressionToCodeTest.B()",
+                ExpressionToCode.With(rules => rules.WithFullTypeNames()).ToCode(() => new B()));
+        }
+
+        class B { }
     }
 
     public delegate int DelegateWithRefAndOut(ref int someVar, out int anotherVar);

--- a/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
+++ b/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
@@ -92,6 +92,14 @@ namespace ExpressionToCodeTest {
         }
 
         [Test]
+        public void ArrayOfFuncInitializer_FullNames()
+        {
+            Assert.AreEqual(
+                @"() => new System.Func<int>[] { () => 1, () => 2 }",
+                ExpressionToCode.With(r => r.WithFullTypeNames()).ToCode(() => new Func<int>[] { () => 1, () => 2 }));
+        }
+
+        [Test]
         public void ListInitializer() {
             Assert.AreEqual(
                 @"() => new Dictionary<int, int> { { 1, 1 }, { 2, 2 }, { 3, 4 } }.Count == 3",

--- a/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
+++ b/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
@@ -466,6 +466,14 @@ namespace ExpressionToCodeTest {
                 "() => new CustomDelegate(n => n + 1)(1)",
                 ExpressionToCode.ToCode(() => new CustomDelegate(n => n + 1)(1)));
         }
+
+        [Test]
+        public void FullTypeName_IfCorrespondingRuleSpecified()
+        {
+            Assert.AreEqual(
+                "() => new ExpressionToCodeTest.ClassA()",
+                ExpressionToCode.With(rules => rules.WithFullTypeNames()).ToCode(() => new ClassA()));
+        }
     }
 
     public delegate int DelegateWithRefAndOut(ref int someVar, out int anotherVar);

--- a/ExpressionToCodeTest/GenericsTestClasses.cs
+++ b/ExpressionToCodeTest/GenericsTestClasses.cs
@@ -189,7 +189,19 @@ namespace ExpressionToCodeTest {
                 ExpressionToCode.ToCode(() => GenericClass<int>.IsFunc2OfType((int x) => x))
                 );
         }
+
+        [Test]
+        public void GenericMethodCall_WhenSomeNotInferredTypeArguments_ShouldExplicitlySpecifyTypeArguments()
+        {
+            Assert.AreEqual(
+                "() => MakeMe<Cake, string>(() => new Cake())",
+                ExpressionToCode.With(rules => rules.WithExplicitMethodTypeArgs()).ToCode(() => MakeMe<Cake, string>(() => new Cake())));
+        }
+
+        T MakeMe<T, TNotInferredFromArgument>(Func<T> maker) { return maker(); }
     }
+
+    internal class Cake { }
 
     class GenericClass<T> {
         T val;


### PR DESCRIPTION
Compared to previous PR fixed Nested Type name, made CSharpFriendlyTypeName public.