### PR TITLE
Fix stackoverflow error in stringification of generic type arguments.

### DIFF
--- a/ExpressionToCodeLib/CSharpFriendlyTypeName.cs
+++ b/ExpressionToCodeLib/CSharpFriendlyTypeName.cs
@@ -55,10 +55,10 @@ namespace ExpressionToCodeLib
 
         static string NormalName(Type type, bool useFullName = false)
         {
-            return type.DeclaringType != null
-                ? Get(type.DeclaringType, useFullName) + "." + type.Name
-                : type.IsGenericParameter
-                    ? type.Name
+            return type.IsGenericParameter
+                ? type.Name
+                : type.DeclaringType != null
+                    ? Get(type.DeclaringType, useFullName) + "." + type.Name
                     : useFullName ? type.FullName : type.Name;
         }
 


### PR DESCRIPTION
PR #42 introduced a stackoverflow in stringifying generic arguments.

This was caused due to the fact that arguments are nested types; So a type `Bla<Z>` would actually render as `Bla<ParentOfZ.Z>` with `ParentOfZ` infinitely recursing.
The fix is to not specify the parent of a generic argument (this is never necessary in normal cases, and I can't think of a case where it is).