### PR TITLE
Update benchmarks for reasonable baseline

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -10,3 +10,4 @@ ExpressionToCodeLib/*.nupkg
 *.received.txt
 TestResults/**.coverage
 *.orig
+ExpressionToCode.Benchmarks/BenchmarkDotNet.Artifacts

--- a/ExpressionToCode.Benchmarks/ExpressionToCode.Benchmarks.csproj
+++ b/ExpressionToCode.Benchmarks/ExpressionToCode.Benchmarks.csproj
@@ -9,53 +9,53 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ExpressionToCodeLib\ExpressionToCodeLib.csproj" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.3"/>
-    <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.3"/>
-    <PackageReference Include="BenchmarkDotNet.Toolchains.Roslyn" Version="0.10.3"/>
-    <PackageReference Include="JetBrains.Annotations" Version="10.4.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="1.3.2"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2"/>
-    <PackageReference Include="System.AppContext" Version="4.1.0"/>
-    <PackageReference Include="System.Collections" Version="4.0.11"/>
-    <PackageReference Include="System.Collections.Concurrent" Version="4.0.12"/>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0"/>
-    <PackageReference Include="System.Console" Version="4.0.0"/>
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11"/>
-    <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.0.0"/>
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.0.1"/>
-    <PackageReference Include="System.Diagnostics.Tools" Version="4.0.1"/>
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11"/>
-    <PackageReference Include="System.Globalization" Version="4.0.11"/>
-    <PackageReference Include="System.IO.FileSystem" Version="4.0.1"/>
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.0.1"/>
-    <PackageReference Include="System.Linq" Version="4.3.0"/>
-    <PackageReference Include="System.Linq.Expressions" Version="4.1.0"/>
-    <PackageReference Include="System.Reflection" Version="4.1.0"/>
-    <PackageReference Include="System.Reflection.Metadata" Version="1.3.0"/>
-    <PackageReference Include="System.Reflection.Primitives" Version="4.0.1"/>
-    <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1"/>
-    <PackageReference Include="System.Runtime" Version="4.1.0"/>
-    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0"/>
-    <PackageReference Include="System.Runtime.Handles" Version="4.0.1"/>
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.1.0"/>
-    <PackageReference Include="System.Runtime.Numerics" Version="4.0.1"/>
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.2.0"/>
-    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.0.0"/>
-    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.0.0"/>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.1.0"/>
-    <PackageReference Include="System.Text.Encoding" Version="4.0.11"/>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1"/>
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.11"/>
-    <PackageReference Include="System.Threading" Version="4.0.11"/>
-    <PackageReference Include="System.Threading.Tasks" Version="4.0.11"/>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0"/>
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.0.1"/>
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0"/>
-    <PackageReference Include="System.Xml.ReaderWriter" Version="4.0.11"/>
-    <PackageReference Include="System.Xml.XDocument" Version="4.0.11"/>
-    <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1"/>
-    <PackageReference Include="System.Xml.XPath" Version="4.0.1"/>
-    <PackageReference Include="System.Xml.XPath.XDocument" Version="4.0.1"/>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
+    <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.3" />
+    <PackageReference Include="BenchmarkDotNet.Toolchains.Roslyn" Version="0.10.3" />
+    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
+    <PackageReference Include="System.AppContext" Version="4.3.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="System.Console" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XPath.XDocument" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/ExpressionToCodeTest/ExpressionToCodeTest.csproj
+++ b/ExpressionToCodeTest/ExpressionToCodeTest.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='netcoreapp1.1' ">
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />


### PR DESCRIPTION
For #66 
Current run:

```
Total time: 00:00:29 (29.98 sec)

// * Summary *

BenchmarkDotNet=v0.10.3.0, OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-4770K CPU 3.50GHz, ProcessorCount=8
Frequency=3421924 Hz, Resolution=292.2333 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1637.0
  DefaultJob : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1637.0


                  Method |            Mean |        StdDev |
------------------------ |---------------- |-------------- |
             JustCompile | 387,833.5391 ns | 1,684.2367 ns |
         JustFastCompile | 408,025.1694 ns | 2,474.3424 ns |
      PAssertWithCompile | 398,859.9365 ns | 1,349.2918 ns |
  PAssertWithFastCompile | 412,164.3795 ns | 3,032.0369 ns |
 BaseLinePlainLambdaExec |     119.0290 ns |     0.2387 ns |

*** Hints ***
Outliers
  BenchmarkPAssert.JustCompile: Default        -> 1 outlier  was  removed
  BenchmarkPAssert.PAssertWithCompile: Default -> 2 outliers were removed

```