### PR TITLE
Do not output subexpressions that don't have value available

### DIFF
--- a/ExpressionToCodeLib/Internal/SubExpressionPerLineCodeAnnotator.cs
+++ b/ExpressionToCodeLib/Internal/SubExpressionPerLineCodeAnnotator.cs
@@ -72,7 +72,9 @@ namespace ExpressionToCodeLib.Internal
                     var subExprString = sb.Length <= maxSize
                         ? sb.ToString()
                         : sb.ToString(0, maxSize / 2 - 1) + "  …  " + sb.ToString(sb.Length - (maxSize / 2 - 1), maxSize / 2 - 1);
-                    subExpressionValues.Add(new SubExpressionValue { SubExpression = subExprString, ValueAsString = valueString });
+                    if (valueString != "") {
+                        subExpressionValues.Add(new SubExpressionValue { SubExpression = subExprString, ValueAsString = valueString });
+                    }
                 }
                 foreach (var kid in node.Children) {
                     if (kid.IsConceptualChild) {

--- a/ExpressionToCodeLib/Internal/SubExpressionPerLineCodeAnnotator.cs
+++ b/ExpressionToCodeLib/Internal/SubExpressionPerLineCodeAnnotator.cs
@@ -66,13 +66,13 @@ namespace ExpressionToCodeLib.Internal
                 if (!hideOutermostValue && node.OptionalValue != null) {
                     var sb = new StringBuilder();
                     var ignoreInitialSpace = true;
-                    var valueString = ObjectToCodeImpl.ExpressionValueAsCode(config, node.OptionalValue, 10) ?? "";
+                    var valueString = ObjectToCodeImpl.ExpressionValueAsCode(config, node.OptionalValue, 10);
                     AppendNodeToStringBuilder(sb, subExprNode, ref ignoreInitialSpace);
                     var maxSize = 80;
                     var subExprString = sb.Length <= maxSize
                         ? sb.ToString()
                         : sb.ToString(0, maxSize / 2 - 1) + "  …  " + sb.ToString(sb.Length - (maxSize / 2 - 1), maxSize / 2 - 1);
-                    if (valueString != "") {
+                    if (!string.IsNullOrEmpty(valueString)) {
                         subExpressionValues.Add(new SubExpressionValue { SubExpression = subExprString, ValueAsString = valueString });
                     }
                 }

--- a/ExpressionToCodeTest/ExpressionToCodeTest.csproj
+++ b/ExpressionToCodeTest/ExpressionToCodeTest.csproj
@@ -14,7 +14,7 @@
   <ItemGroup Condition="$(TargetFramework)=='netcoreapp1.1' ">
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170113-02" />
-    <PackageReference Include="JetBrains.Annotations" Version="10.2.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />

--- a/ExpressionToCodeTest/SubExpressionPerLineCodeAnnotatorTest.DealsOkWithLongEnumerables.approved.txt
+++ b/ExpressionToCodeTest/SubExpressionPerLineCodeAnnotatorTest.DealsOkWithLongEnumerables.approved.txt
@@ -1,10 +1,4 @@
 () => Enumerable.Range(0, 1000).ToDictionary(i => "n" + i)["n3"].ToString(CultureInfo.InvariantCulture) == 3.5.ToString(CultureInfo.InvariantCulture)
-CultureInfo.InvariantCulture
-     →   
-i
-     →   
-"n" + i
-     →   
 Enumerable.Range(0, 1000)
      →   {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, ...}
 Enumerable.Range(0, 1000).ToDictionary(i => "n" + i)

--- a/ExpressionToCodeTest/SubExpressionPerLineCodeAnnotatorTest.NodesThatAreUndescribableAreNotDescribed.approved.txt
+++ b/ExpressionToCodeTest/SubExpressionPerLineCodeAnnotatorTest.NodesThatAreUndescribableAreNotDescribed.approved.txt
@@ -1,0 +1,9 @@
+() => list.Select(e => e + 1).Count() == 5
+list
+     →   {1, 2, 3, 3, 2, 1}
+list.Select(e => e + 1)
+     →   {2, 3, 4, 4, 3, 2}
+list.Select(e => e + 1).Count()
+     →   6
+list.Select(e => e + 1).Count() == 5
+     →   false

--- a/ExpressionToCodeTest/SubExpressionPerLineCodeAnnotatorTest.cs
+++ b/ExpressionToCodeTest/SubExpressionPerLineCodeAnnotatorTest.cs
@@ -137,5 +137,12 @@ namespace ExpressionToCodeTest
             var nums = Enumerable.Range(10, 10).ToArray();
             ApprovalTest.Verify(annotator.AnnotatedToCode(() => a < b && nums[a + b] < 7 && b < 10));
         }
+
+        [Fact]
+        public void NodesThatAreUndescribableAreNotDescribed()
+        {
+            var list = new List<int> { 1, 2, 3, 3, 2, 1 };
+            ApprovalTest.Verify(annotator.AnnotatedToCode(() => list.Select(e => e + 1).Count() == 5));
+        }
     }
 }


### PR DESCRIPTION
This should solve #74 .

If you want, I can make the behavior configurable by adding something like `bool OmitNodesWithEmptyDescription` to `ExpressionToCodeConfigurationValue`. I decided to not complicate interface by such option.

Oh, and I upgraded `JetBrains.Annotations` in the test project as msbuild complained about mismatch with the version in the main project.