### PR TITLE
Add support for throw expressions

### DIFF
--- a/ExpressionToCodeLib/Internal/ExpressionToCodeImpl.cs
+++ b/ExpressionToCodeLib/Internal/ExpressionToCodeImpl.cs
@@ -1069,7 +1069,15 @@ namespace ExpressionToCodeLib.Internal
 
         [Pure]
         public StringifiedExpression DispatchThrow(Expression e)
-            => throw new NotImplementedException();
+        {
+            var kids = KidsBuilder.Create();
+            var ue = (UnaryExpression)e;
+
+            kids.Add("throw ");
+            kids.Add(this.ExpressionDispatch(ue.Operand));
+
+            return kids.Finish();
+        }
 
         [Pure]
         public StringifiedExpression DispatchTry(Expression e)

--- a/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
+++ b/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
@@ -620,6 +620,21 @@ namespace ExpressionToCodeTest
             Assert.Equal(@"() => someValue + closedVariable + "" "" + argument", expr);
         }
 
+        [Fact]
+        public void ThisThrow()
+        {
+            var expr = ExpressionToCode.ToCode(
+                Expression.Throw(
+                    Expression.New(
+                        typeof(Exception).GetConstructor(new[] { typeof(string) }) ??
+                        throw new InvalidOperationException("Unable to find exception constructor"),
+                        Expression.Constant("Stuff")
+                    )
+                )
+            );
+            Assert.Equal("throw new Exception(\"Stuff\")", expr);
+        }
+
         // ReSharper disable once ClassCanBeSealed.Local
         class ClassWithClosure
         {


### PR DESCRIPTION
Example usage:

```csharp
var expression = Expression.Throw(
    Expression.New(
        typeof(YourCustomException).GetConstructor(new []{typeof(string)}),
        Expression.Constant("Something went wrong!")
    )
);

return ExpressionToCode.ToCode(expression);
```

which generates

```
throw new YourCustomException("Something went wrong!");
```