### PR TITLE
Option disable literal strings

### DIFF
--- a/ExpressionToCodeLib/IObjectStringifier.cs
+++ b/ExpressionToCodeLib/IObjectStringifier.cs
@@ -6,6 +6,7 @@ namespace ExpressionToCodeLib
     {
         string? PlainObjectToCode(object? val, Type? type);
         string TypeNameToCode(Type type);
+        bool PreferLiteralSyntax(string str1);
     }
 
     public static class ObjectStringifierExtensions

--- a/ExpressionToCodeLib/Internal/ExpressionToCodeImpl.cs
+++ b/ExpressionToCodeLib/Internal/ExpressionToCodeImpl.cs
@@ -413,7 +413,7 @@ namespace ExpressionToCodeLib.Internal
                             ? StringifiedExpression.WithChildren(new[] { StringifiedExpression.TextOnly("("), this.ExpressionDispatch(child), StringifiedExpression.TextOnly(")") })
                             : this.ExpressionDispatch(child)
                 ).ToArray();
-            var useLiteralSyntax = ObjectStringifyImpl.PreferLiteralSyntax(formatString)
+            var useLiteralSyntax = objectStringifier.PreferLiteralSyntax(formatString)
                 || StringifiedExpression.WithChildren(interpolationArgumentsStringified).ToString().Contains("\n");
 
             var parsed = FormatStringParser.ParseFormatString(formatString, interpolationArgumentsStringified.Cast<object>().ToArray());

--- a/ExpressionToCodeLib/Internal/ObjectStringifyImpl.cs
+++ b/ExpressionToCodeLib/Internal/ObjectStringifyImpl.cs
@@ -9,9 +9,13 @@ namespace ExpressionToCodeLib.Internal
     sealed class ObjectStringifyImpl : IObjectStringifier
     {
         readonly bool fullTypeNames;
+        readonly bool allowRawStrings;
 
-        public ObjectStringifyImpl(bool fullTypeNames = false)
-            => this.fullTypeNames = fullTypeNames;
+        public ObjectStringifyImpl(bool fullTypeNames = false, bool allowRawStrings = true)
+        {
+            this.fullTypeNames = fullTypeNames;
+            this.allowRawStrings = allowRawStrings;
+        }
 
         public string TypeNameToCode(Type type)
             => new CSharpFriendlyTypeName { UseFullName = fullTypeNames }.GetTypeName(type);
@@ -61,8 +65,12 @@ namespace ExpressionToCodeLib.Internal
             }
         }
 
-        internal static bool PreferLiteralSyntax(string str1)
+        public bool PreferLiteralSyntax(string str1)
         {
+            if (!allowRawStrings) {
+                return false;
+            }
+
             var count = 0;
             foreach (var c in str1) {
                 if (c < 32 && c != '\r' || c == '\\') {

--- a/ExpressionToCodeLib/ObjectStringify.cs
+++ b/ExpressionToCodeLib/ObjectStringify.cs
@@ -8,5 +8,7 @@ namespace ExpressionToCodeLib
     {
         public static readonly IObjectStringifier Default = new ObjectStringifyImpl();
         public static readonly IObjectStringifier WithFullTypeNames = new ObjectStringifyImpl(true);
+        public static readonly IObjectStringifier WithoutLiteralStrings = new ObjectStringifyImpl(false, false);
+        public static readonly IObjectStringifier WithFullTypeNamesWithoutLiteralStrings = new ObjectStringifyImpl(true, false);
     }
 }

--- a/ExpressionToCodeTest/ApiStabilityTest.PublicApi.approved.txt
+++ b/ExpressionToCodeTest/ApiStabilityTest.PublicApi.approved.txt
@@ -26,6 +26,7 @@ interface IExpressionToCode
 interface IObjectStringifier
     string inst.PlainObjectToCode(object val, Type type)
     string inst.TypeNameToCode(Type type)
+    bool inst.PreferLiteralSyntax(string str1)
 
 class AnnotatedToCodeExtensions
     string TYPE.AnnotatedToCode(IAnnotatedToCode it, Expression e)
@@ -118,6 +119,8 @@ class ObjectStringifierExtensions
 class ObjectStringify
     static readonly IObjectStringifier Default
     static readonly IObjectStringifier WithFullTypeNames
+    static readonly IObjectStringifier WithoutLiteralStrings
+    static readonly IObjectStringifier WithFullTypeNamesWithoutLiteralStrings
 
 class ObjectToCode
     string TYPE.ComplexObjectToPseudoCode(object val)

--- a/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
+++ b/ExpressionToCodeTest/ExpressionToCodeLibTest.cs
@@ -557,6 +557,25 @@ namespace ExpressionToCodeTest
             Assert.Equal("() => new ExpressionToCodeTest.ExpressionToCodeLibTest.B()", code);
         }
 
+        [Fact]
+        public void WithLiteralStrings()
+        {
+            var code = ExpressionToCodeConfiguration.DefaultCodeGenConfiguration.WithObjectStringifier(ObjectStringify.Default)
+                .GetExpressionToCode()
+                .ToCode(static () => "Lots \t of \t tabs \t that \t will \t need \t escaping");
+
+            Assert.Equal("() => @\"Lots \t of \t tabs \t that \t will \t need \t escaping\"", code);
+        }
+
+        [Fact]
+        public void WithoutLiteralStrings()
+        {
+            var code = ExpressionToCodeConfiguration.DefaultCodeGenConfiguration.WithObjectStringifier(ObjectStringify.WithoutLiteralStrings)
+                .GetExpressionToCode()
+                .ToCode(static () => "Lots \t of \t tabs \t that \t will \t need \t escaping");
+            Assert.Equal("() => \"Lots \\t of \\t tabs \\t that \\t will \\t need \\t escaping\"", code);
+        }
+
         sealed class B { }
 
         [Fact]


### PR DESCRIPTION
In some environments, such as Dynamic LINQ (`System.Linq.Dynamic`), literal strings are not supported. As such, an option to disable generating code using these would be useful.